### PR TITLE
Fix typo in setup.cfg that break wheel creation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,4 +6,4 @@ ignore = E123,E128,E402,W503,E731,W601
 max-line-length = 119
 
 [metadata]
-license-file = LICENSE
+license-file = LICENSE.md


### PR DESCRIPTION
I could not get pip to build a wheel for this package due to a typo in the setup.cfg. The file was referencing LICENSE instead of LICENSE.md.