### PR TITLE
Feature/allow urls

### DIFF
--- a/amp_tools/middleware.py
+++ b/amp_tools/middleware.py
@@ -1,3 +1,4 @@
+import re
 
 from amp_tools.settings import settings
 from amp_tools import set_amp_detect
@@ -8,6 +9,15 @@ class AMPDetectionMiddleware(object):
     def process_request(self, request):
         if settings.AMP_TOOLS_GET_PARAMETER in request.GET:
             if request.GET[settings.AMP_TOOLS_GET_PARAMETER] == settings.AMP_TOOLS_GET_VALUE:
-                set_amp_detect(is_amp_detect=True, request=request)
+                if settings.AMP_TOOLS_ACTIVE_URLS:
+                    for url in settings.AMP_TOOLS_ACTIVE_URLS:
+                        if not isinstance(url, re._pattern_type):
+                            url = str(url)
+                        url_re = re.compile(url)
+
+                        if url_re.match(request.path_info):
+                            set_amp_detect(is_amp_detect=True, request=request)
+                else:
+                    set_amp_detect(is_amp_detect=True, request=request)
         else:
             set_amp_detect(is_amp_detect=False, request=request)

--- a/amp_tools/settings.py
+++ b/amp_tools/settings.py
@@ -28,6 +28,7 @@ class defaults(object):
     AMP_TOOLS_TEMPLATE_PREFIX = u''
     AMP_TOOLS_GET_PARAMETER = u'amp-content'
     AMP_TOOLS_GET_VALUE = u'amp'
+    AMP_TOOLS_ACTIVE_URLS = []
 
     AMP_TOOLS_TEMPLATE_LOADERS = []
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,7 @@
 
 import threading
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from mock import MagicMock, Mock, patch, call
 
@@ -44,3 +44,26 @@ class DetectAMPMiddlewareTests(BaseTestCase):
         middleware = AMPDetectionMiddleware()
         middleware.process_request(request)
         self.assertEqual(set_amp_detect.call_args, call(is_amp_detect=True, request=request))
+
+    @patch('amp_tools.middleware.set_amp_detect')
+    @override_settings(AMP_TOOLS_ACTIVE_URLS=['^/$'])
+    def test_set_amp_not_set_url_not_allowed(self, set_amp_detect):
+        request = Mock()
+        request.META = MagicMock()
+        request.GET = {'amp-content': 'amp'}
+        request.path_info = '/'
+        middleware = AMPDetectionMiddleware()
+        middleware.process_request(request)
+        self.assertEqual(set_amp_detect.call_args, call(is_amp_detect=True, request=request))
+
+    @patch('amp_tools.middleware.set_amp_detect')
+    @override_settings(AMP_TOOLS_ACTIVE_URLS=['^/$'])
+    def test_set_amp_not_set_url_not_allowed(self, set_amp_detect):
+        request = Mock()
+        request.META = MagicMock()
+        request.GET = {'amp-content': 'amp'}
+        request.path_info = '/not-amp-url/'
+        middleware = AMPDetectionMiddleware()
+        middleware.process_request(request)
+        self.assertEqual(0, len(set_amp_detect.call_args_list))
+

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,12 +2,9 @@ from __future__ import unicode_literals
 
 import threading
 
-<<<<<<< HEAD
-from django.test import TestCase
-from django.template import Template, RequestContext
-=======
 from django.test import TestCase, override_settings
->>>>>>> feature/allow_only_some_urls
+from django.template import Template, RequestContext
+
 
 from mock import MagicMock, Mock, patch, call
 


### PR DESCRIPTION
Some times only some urls we want to be active in AMP.

Define url patterns in settings and only those who matches regex pattern can be AMP active.

If no pattern are defined, normal behavior .