### PR TITLE
Always set "amp-content" GET parameter as the first one.

### DIFF
--- a/amp_tools/templatetags/amp_tags.py
+++ b/amp_tools/templatetags/amp_tags.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+from collections import OrderedDict
+
 from django import template
 from django.contrib.sites.models import Site
 from django.http import QueryDict
@@ -7,6 +9,7 @@ from django.utils.safestring import mark_safe
 from django.utils.encoding import force_text
 from django.template import Library, Node, Variable
 from django.template.defaultfilters import stringfilter
+from six.moves.urllib.parse import urlencode
 
 register = template.Library()
 
@@ -15,16 +18,17 @@ from amp_tools.settings import settings
 
 @register.simple_tag
 def amp_canonical_link(request):
-    getvars = request.GET.copy()
+    getvars = OrderedDict(request.GET.copy().items())
     rel = "amphtml"
     if settings.AMP_TOOLS_GET_PARAMETER in getvars:
         del getvars[settings.AMP_TOOLS_GET_PARAMETER]
         rel = "canonical"
     else:
         getvars[settings.AMP_TOOLS_GET_PARAMETER] = settings.AMP_TOOLS_GET_VALUE
+        getvars.move_to_end(settings.AMP_TOOLS_GET_PARAMETER, last=False)
 
     if len(getvars.keys()) > 0:
-        getvars = getvars.urlencode()
+        getvars = urlencode(getvars)
     else:
         getvars = ''
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ VENV_LINK = os.path.join(VENV, 'local')
 
 install_requires = [
     'django>=1.8.0',
+    'six>=1.11.0',
 ]
 
 

--- a/tests/requirements.pip
+++ b/tests/requirements.pip
@@ -8,3 +8,4 @@ ipdb==0.10.1
 sphinx==1.4.5
 mock==1.3.0
 django-test-without-migrations==0.4
+six==1.11.0


### PR DESCRIPTION
Fixes shtalinberg/django-amp-tools#10